### PR TITLE
collision_avoidance for service names

### DIFF
--- a/config.hcl
+++ b/config.hcl
@@ -3,6 +3,7 @@ Declare as many services as you need
 for your machine */
 
 bind_address = "192.168.2.21"
+collision_avoidance = "hostname"
 
 service {
     name = "Etcd"

--- a/pkg/publisher/publisher.go
+++ b/pkg/publisher/publisher.go
@@ -9,15 +9,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type Service struct {
-	Name     string `mapstructure:"name"`
-	HostName string `mapstructure:"host_name"`
-	SvcType  string `mapstructure:"type"`
-	Domain   string `mapstructure:"domain"`
-	Port     int    `mapstructure:"port"`
-	TTL      uint32 `mapstructure:"ttl"`
-}
-
 var log = logrus.New()
 
 func Publish(ip net.IP, iface net.Interface, service Service, shutdown chan struct{}, waitGroup *sync.WaitGroup) (err error) {
@@ -80,4 +71,8 @@ func FindIface(ip net.IP) (iface net.Interface, err error) {
 		}
 	}
 	return iface, fmt.Errorf("Couldn't find interface with IP address %s", ip)
+}
+
+func SetLogLevel(level logrus.Level) {
+	log.SetLevel(level)
 }

--- a/pkg/publisher/service.go
+++ b/pkg/publisher/service.go
@@ -1,0 +1,84 @@
+package publisher
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+type CollisionStrategy int
+
+const (
+	Inaction CollisionStrategy = iota
+	HostName
+)
+
+var (
+	strategies = []string{
+		"Inaction",
+		"HostName",
+	}
+)
+
+type Service struct {
+	Name     string `mapstructure:"name"`
+	HostName string `mapstructure:"host_name"`
+	SvcType  string `mapstructure:"type"`
+	Domain   string `mapstructure:"domain"`
+	Port     int    `mapstructure:"port"`
+	TTL      uint32 `mapstructure:"ttl"`
+}
+
+func (strategy CollisionStrategy) String() (string, error) {
+	if err := strategy.valid(); err != nil {
+		return "", err
+	}
+	return strategies[strategy], nil
+}
+
+func NewCollisionStrategy(strategy string) (CollisionStrategy, error) {
+	for i, name := range strategies {
+		if strings.EqualFold(strategy, name) {
+			return CollisionStrategy(i), nil
+		}
+	}
+	return CollisionStrategy(-1), fmt.Errorf("Unrecognized CollisionStrategy %s", strategy)
+}
+
+func CollisionStrategies() []string {
+	return strategies
+}
+
+func (strategy CollisionStrategy) valid() error {
+	if strategy < Inaction || strategy > HostName {
+		return fmt.Errorf("Unrecognized CollisionStrategy")
+	}
+	return nil
+}
+
+func (s *Service) AlterName(strategy CollisionStrategy) error {
+	if err := strategy.valid(); err != nil {
+		return err
+	}
+
+	switch strategy {
+	case Inaction:
+		return nil
+	case HostName:
+		hostName, err := os.Hostname()
+		if err != nil {
+			return err
+		}
+		shortName := strings.Split(hostName, ".")[0]
+		originalName := s.Name
+		s.Name = originalName + "-" + shortName
+		log.WithFields(logrus.Fields{
+			"original": originalName,
+			"new":      s.Name,
+		}).Debug("Changing service name")
+		return nil
+	}
+	return fmt.Errorf("Unimplemented collision avoidance strategy")
+}


### PR DESCRIPTION
In issue #1 we found that when nodes expose the same service name only
one gets to be found. This patch adds a strategy that append the short
hostname to the service name to reduce the change of collision.

Other collision avoidance strategies may be implemented.