### PR TITLE
Allow overriding of the service IP

### DIFF
--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -87,7 +87,11 @@ var publishCmd = &cobra.Command{
 				"port":     service.Port,
 				"ttl":      service.TTL,
 			}).Info("Publishing service")
-			go publisher.Publish(ip, iface, service, shutdownChannel, waitGroup)
+			serviceIP := ip
+			if service.AddrIPv4 != "" {
+				serviceIP = net.ParseIP(service.AddrIPv4)
+			}
+			go publisher.Publish(serviceIP, iface, service, shutdownChannel, waitGroup)
 		}
 
 		<-sig

--- a/pkg/publisher/service.go
+++ b/pkg/publisher/service.go
@@ -29,6 +29,7 @@ type Service struct {
 	Domain   string `mapstructure:"domain"`
 	Port     int    `mapstructure:"port"`
 	TTL      uint32 `mapstructure:"ttl"`
+	AddrIPv4 string `mapstructure:"ip"`
 }
 
 func (strategy CollisionStrategy) String() (string, error) {


### PR DESCRIPTION
Currently the service IP is always assigned based on the bind_address
setting. For the api-int service we need to be able to specify a
different IP (the API VIP). This change adds an optional "ip" parameter
to the service config which, if set, overrides bind_address as the
AddrIPv4 value for the service.