### PR TITLE
Exit if interface loses IP

### DIFF
--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -89,10 +89,15 @@ var publishCmd = &cobra.Command{
 			}).Info("Publishing service")
 			go publisher.Publish(ip, iface, service, shutdownChannel, waitGroup)
 		}
+		ifaceChanged := make(chan struct{})
+		go publisher.IfaceCheck(ip, iface, ifaceChanged)
 
-		<-sig
+		select {
+			case <-sig:
+			case <-ifaceChanged:
+		}
 		close(shutdownChannel)
-		log.Info("SIGTERM received, gracefully shutting down services...")
+		log.Info("Shutdown request received, gracefully shutting down services...")
 		waitGroup.Wait()
 		log.Info("Done!")
 	},


### PR DESCRIPTION
On startup, mdns-publisher looks up which interface has the configured
IP. However, it is possible for this IP to be subsequently moved,
such as when the interface gets added to a bridge. In that case, we
need to be restarted and listen on the bridge or our records become
inaccessible.

This change adds a goroutine that loops every five seconds checking
if the detected interface still has the configured IP. If it does not,
the function sends a SIGTERM to the process to exit gracefully.
This should allow kubernetes to restart it on the correct interface.