### PR TITLE
Check that go fmt has no changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 .PHONY: fmt
 fmt: ## Run go fmt against code
 	go fmt ./pkg/... ./cmd/...
+	git diff --exit-code
 
 .PHONY: vet
 vet: ## Run go vet against code

--- a/cmd/publish.go
+++ b/cmd/publish.go
@@ -93,8 +93,8 @@ var publishCmd = &cobra.Command{
 		go publisher.IfaceCheck(ip, iface, ifaceChanged)
 
 		select {
-			case <-sig:
-			case <-ifaceChanged:
+		case <-sig:
+		case <-ifaceChanged:
 		}
 		close(shutdownChannel)
 		log.Info("Shutdown request received, gracefully shutting down services...")

--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,5 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.4.0
 )
+
+go 1.13


### PR DESCRIPTION
Previously the makefile only ran go fmt but didn't verify whether it
had to make changes. This adds a git diff --exit-code call to the
target so it will fail if the code was not formatted properly.