### PR TITLE
Bug 1915122: Truncate long service names to 63 characters

### DIFF
--- a/pkg/publisher/publisher_test.go
+++ b/pkg/publisher/publisher_test.go
@@ -163,3 +163,23 @@ func (networkInterfaceWithInvalidAddr) Addrs(intf *net.Interface) ([]net.Addr, e
 func (networkInterfaceWithInvalidAddr) Interfaces() ([]net.Interface, error) {
 	return []net.Interface{upIntf}, nil
 }
+
+func TestLongNameTruncation(t *testing.T) {
+	testCases := []struct {
+		tcase    string
+		name     string
+		expected string
+	}{
+		{"short name", "master-0", "master-0"},
+		{"long name", "prefix-someverylongservicenamethatwouldcauseaproblemfordns-suffix", "prefix-somevery47540ff49304816bc5054bb4f3cc9a9clemfordns-suffix"},
+	}
+	for _, tc := range testCases {
+		result := truncateLongServiceName(tc.name)
+		if result != tc.expected {
+			t.Errorf("case[%v]: expected %v, got %v", tc.tcase, tc.expected, result)
+		}
+		if len(result) > 63 {
+			t.Errorf("case[%v]: Truncated name too long: '%v' is %d characters long", tc.tcase, result, len(result))
+		}
+	}
+}


### PR DESCRIPTION
In some environments, the combination of cluster name and hostname
can get long enough that a service name exceeds 63 characters. This
is not allowed by the dns library, so we need to ensure that we never
pass it such long names.

This change shortens the name by hashing it to 32 characters, then
sandwiching that between the first 15 and last 16 characters of the
original name. This way the likely unique parts of the name are
preserved, but the total length of the name is shortened to an
allowable length. Something similar to kubernetes->k8s.