### PR TITLE
Bug 1989896: Bump Go to 1.16

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: golang-1.12
+  tag: golang-1.16


### PR DESCRIPTION
1.12 is too old for a necessary version bump in one of our dependencies.